### PR TITLE
Removes 'press to shutdown' notification. 

### DIFF
--- a/android_core_components/src/org/ros/android/NodeMainExecutorService.java
+++ b/android_core_components/src/org/ros/android/NodeMainExecutorService.java
@@ -16,8 +16,6 @@
 
 package org.ros.android;
 
-import com.google.common.base.Preconditions;
-
 import android.app.AlertDialog;
 import android.app.Notification;
 import android.app.NotificationChannel;
@@ -41,6 +39,7 @@ import android.os.PowerManager.WakeLock;
 import android.util.Log;
 import android.view.WindowManager;
 import android.widget.Toast;
+
 import org.ros.RosCore;
 import org.ros.android.android_core_components.R;
 import org.ros.concurrent.ListenerGroup;
@@ -214,16 +213,6 @@ public class NodeMainExecutorService extends Service implements NodeMainExecutor
   public int onStartCommand(Intent intent, int flags, int startId) {
     if (intent.getAction() == null) {
       return START_NOT_STICKY;
-    }
-    if (intent.getAction().equals(ACTION_START)) {
-      Preconditions.checkArgument(intent.hasExtra(EXTRA_NOTIFICATION_TICKER));
-      Preconditions.checkArgument(intent.hasExtra(EXTRA_NOTIFICATION_TITLE));
-      Intent notificationIntent = new Intent(this, NodeMainExecutorService.class);
-      notificationIntent.setAction(NodeMainExecutorService.ACTION_SHUTDOWN);
-      PendingIntent pendingIntent = PendingIntent.getService(this, 0, notificationIntent, 0);
-      Notification notification = buildNotification(intent, pendingIntent);
-
-      startForeground(ONGOING_NOTIFICATION, notification);
     }
     if (intent.getAction().equals(ACTION_SHUTDOWN)) {
       shutdown();

--- a/android_core_components/src/org/ros/android/RosActivity.java
+++ b/android_core_components/src/org/ros/android/RosActivity.java
@@ -216,7 +216,7 @@ public abstract class RosActivity extends Activity {
             removeListener(nodeMainExecutorServiceConnection.getServiceListener());
     if (!shutdownSignalReceived) {
       //shutdown if RosActivity is not finished by a shutdown signal
-      nodeMainExecutorService.shutdown();
+      nodeMainExecutorService.forceShutdown();
     }
     super.onDestroy();
   }

--- a/android_core_components/src/org/ros/android/RosActivity.java
+++ b/android_core_components/src/org/ros/android/RosActivity.java
@@ -1,12 +1,12 @@
 /*
  * Copyright (C) 2011 Google Inc.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -153,7 +153,7 @@ public abstract class RosActivity extends Activity {
    * Use this constructor to proceed using the standard {@link MasterChooser}.
    * @param notificationTicker Title to use in Ticker notifications.
    * @param notificationTitle Title to use in notifications.
-     */
+   */
   protected RosActivity(String notificationTicker, String notificationTitle) {
     this(notificationTicker, notificationTitle, null);
   }
@@ -164,7 +164,7 @@ public abstract class RosActivity extends Activity {
    * @param notificationTicker Title to use in Ticker notifications.
    * @param notificationTitle Title to use in notifications.
    * @param customMasterUri URI of the ROS master to connect to.
-     */
+   */
   protected RosActivity(String notificationTicker, String notificationTitle, URI customMasterUri) {
     super();
     this.notificationTicker = notificationTicker;
@@ -182,7 +182,7 @@ public abstract class RosActivity extends Activity {
    * @param notificationTitle Title to use in notifications.
    * @param activity {@link Activity} to launch instead of {@link MasterChooser}.
    * @param requestCode Request identifier to start the given {@link Activity} for a result.
-     */
+   */
   protected RosActivity(String notificationTicker, String notificationTitle, Class<?> activity, int requestCode) {
     this(notificationTicker, notificationTitle);
     masterChooserActivity = activity;
@@ -198,10 +198,12 @@ public abstract class RosActivity extends Activity {
   protected void bindNodeMainExecutorService() {
     Intent intent = new Intent(this, NodeMainExecutorService.class);
     intent.setAction(NodeMainExecutorService.ACTION_START);
+    intent.putExtra(NodeMainExecutorService.EXTRA_NOTIFICATION_TICKER, notificationTicker);
+    intent.putExtra(NodeMainExecutorService.EXTRA_NOTIFICATION_TITLE, notificationTitle);
     startService(intent);
     Preconditions.checkState(
-        bindService(intent, nodeMainExecutorServiceConnection, BIND_AUTO_CREATE),
-        "Failed to bind NodeMainExecutorService.");
+            bindService(intent, nodeMainExecutorServiceConnection, BIND_AUTO_CREATE),
+            "Failed to bind NodeMainExecutorService.");
   }
 
   @Override
@@ -230,7 +232,7 @@ public abstract class RosActivity extends Activity {
    * been initialized with a master {@link URI} via the {@link MasterChooser}
    * and a {@link NodeMainExecutorService} has started. Your {@link NodeMain}s
    * should be started here using the provided {@link NodeMainExecutor}.
-   * 
+   *
    * @param nodeMainExecutor
    *          the {@link NodeMainExecutor} created for this {@link Activity}
    */
@@ -280,7 +282,7 @@ public abstract class RosActivity extends Activity {
    * Custom callbacks should be able to handle custom request codes configured
    * in custom Activity constructor {@link #RosActivity(String, String, Class, int)}.
    * @param callback Action that will be performed when this Activity gets a result.
-     */
+   */
   public void setOnActivityResultCallback(OnActivityResultCallback callback) {
     onActivityResultCallback = callback;
   }

--- a/android_core_components/src/org/ros/android/RosActivity.java
+++ b/android_core_components/src/org/ros/android/RosActivity.java
@@ -198,8 +198,6 @@ public abstract class RosActivity extends Activity {
   protected void bindNodeMainExecutorService() {
     Intent intent = new Intent(this, NodeMainExecutorService.class);
     intent.setAction(NodeMainExecutorService.ACTION_START);
-    intent.putExtra(NodeMainExecutorService.EXTRA_NOTIFICATION_TICKER, notificationTicker);
-    intent.putExtra(NodeMainExecutorService.EXTRA_NOTIFICATION_TITLE, notificationTitle);
     startService(intent);
     Preconditions.checkState(
         bindService(intent, nodeMainExecutorServiceConnection, BIND_AUTO_CREATE),
@@ -211,6 +209,7 @@ public abstract class RosActivity extends Activity {
     unbindService(nodeMainExecutorServiceConnection);
     nodeMainExecutorService.
             removeListener(nodeMainExecutorServiceConnection.getServiceListener());
+    nodeMainExecutorService.shutdown();
     super.onDestroy();
   }
 


### PR DESCRIPTION
Removes the 'press to shutdown' notification.
NodeMainExecutor Service shutsdown when RosActivity is destroyed.
closes #232 and closes #302